### PR TITLE
data_acquisition.py: Added sync delay and documented under FAQ sectio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,22 @@ config = {
     }
 ```
 
+## FAQ's
+
+Q: I am encountering an error when trying to run the capture server, with messages such as __"Device not found or another error occurred: [WinError 10054] An existing connection was forcibly closed by the remote host."__
+
+A: This error typically occurs when the client and server are not properly synchronized, and the client is already sending data before the server is ready to receive it. The current implementation uses a time.sleep(0.1) delay to account for this synchronization, which should cover most cases. However, if the delay is too short or too long for your specific sensor implementation, you may need to adjust this value accordingly.
+
+Important Considerations:
+
+- When adjusting the delay value, keep in mind that print statements in the script can also introduce a small delay, which should be factored into your calculation.
+- Ensure that the delay value is set to a suitable duration to allow for proper synchronization between the client and server.
+
+
+Q: I am experiencing __duplicate timestamps__ when importing data to Studio.
+
+A: Duplicate timestamps may occur when importing data to Studio if the sensor is changed without adjusting the delay value accordingly. To resolve this issue, ensure that the delay value in `data_acquisition.py` script is adjusted in accordance with your implementation to synchronize the server and client. This adjustment will prevent duplicate timestamps and ensure accurate data importation.
+
+
 ## Contributing Guide
 Please do not hesitate to share your sensor integration with the community! Open a [Pull Request](https://github.com/Infineon/deepcraft-micropython-data-acquisition/pulls) with your `sensors/sensor_name.py` and an example configuration in the `README.md`. 🙌

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ config = {
     }
 ```
 
-## FAQ's
+## FAQs
 
 Q: I am encountering an error when trying to run the capture server, with messages such as __"Device not found or another error occurred: [WinError 10054] An existing connection was forcibly closed by the remote host."__
 

--- a/data_acquisition.py
+++ b/data_acquisition.py
@@ -6,6 +6,8 @@ from tcp_server import create_server_socket
 from sensors.pdm_pcm import PDM_PCM  # swap this out for any other sensor
 import time
 
+SYNC_DELAY = 0.1
+
 def main(sensor):
     ip = connect_wifi()
     server_socket = create_server_socket(ip)
@@ -24,7 +26,7 @@ def main(sensor):
             sensor.read_samples(rx_buf)
             packet = struct.pack(full_format, *rx_buf)
             conn.sendall(packet)
-            time.sleep(0.1)
+            time.sleep(SYNC_DELAY)
     except OSError as e:
         print("Connection error:", e)
     finally:

--- a/data_acquisition.py
+++ b/data_acquisition.py
@@ -4,6 +4,7 @@ import network_utils
 from network_utils import connect_wifi
 from tcp_server import create_server_socket
 from sensors.pdm_pcm import PDM_PCM  # swap this out for any other sensor
+import time
 
 def main(sensor):
     ip = connect_wifi()
@@ -23,6 +24,7 @@ def main(sensor):
             sensor.read_samples(rx_buf)
             packet = struct.pack(full_format, *rx_buf)
             conn.sendall(packet)
+            time.sleep(0.1)
     except OSError as e:
         print("Connection error:", e)
     finally:


### PR DESCRIPTION
…n of README.md.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Added time.sleep(0.1) necessary to sync capture server and client. The sleep value is experimental and may change from sensor to sensor. This is also documented now under FAQ's section in README.md.

Related Issue
Currently on running the data_acquisition script as it is, gives error: 
**_Device not found or another error occurred :
[WinError 10054] An existing connection was forcibly closed by the remote host_**

